### PR TITLE
Fix starboard repeats

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -26,7 +26,7 @@ impl Data {
 
         data
     }
-    
+
     fn setup_file_watcher(&self) {
         let config_clone = Arc::clone(&self.config);
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -26,8 +26,7 @@ impl Data {
 
         data
     }
-
-    #[allow(unreachable_code)]
+    
     fn setup_file_watcher(&self) {
         let config_clone = Arc::clone(&self.config);
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 use crate::config::{Config, MessageResponse, MessageResponseKind};
 
@@ -9,13 +9,18 @@ use tokio::sync::RwLock;
 
 pub struct Data {
     pub config: Arc<RwLock<Config>>,
+    pub starboard_cache: Arc<RwLock<HashSet<u64>>>,
 }
 
 impl Data {
     pub fn new(config: Config) -> Data {
         let config = Arc::new(RwLock::new(config));
+        let starboard_cache = Arc::new(RwLock::new(HashSet::new()));
 
-        let data = Data { config };
+        let data = Data {
+            config,
+            starboard_cache,
+        };
 
         data.setup_file_watcher();
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -27,6 +27,7 @@ impl Data {
         data
     }
 
+    #[allow(unreachable_code)]
     fn setup_file_watcher(&self) {
         let config_clone = Arc::clone(&self.config);
 
@@ -38,6 +39,7 @@ impl Data {
                 Event, EventKind, RecursiveMode, Watcher,
             };
 
+            #[allow(unreachable_patterns)]
             let mut watcher = notify::recommended_watcher(move |res| match res {
                 Ok(Event {
                     kind: EventKind::Access(AccessKind::Close(AccessMode::Write)),

--- a/src/reaction_management.rs
+++ b/src/reaction_management.rs
@@ -6,8 +6,6 @@ use serenity::Message;
 use serenity::Reaction;
 use serenity::ReactionType;
 
-use std::collections::HashSet;
-
 pub async fn reaction_management(
     ctx: &serenity::Context,
     data: &Data,

--- a/src/reaction_management.rs
+++ b/src/reaction_management.rs
@@ -39,6 +39,7 @@ pub async fn starboard(
         .map_or(0, |reaction| reaction.count);
 
     let config = data.config.read().await;
+    let starboard_cache = data.starboard_cache.read().await;
 
     let reaction_count_requirement = *config.get_starboard_reaction_count();
     let stored_name = config.get_starboard_emote();


### PR DESCRIPTION
This should fix the repeat detection for starboard messages, in a more efficient and more resilient way. I'm having issues with the environment setup so my testing bot wouldn't run, but I'm pretty confident I did the thread-safety correctly and efficiently. Cache automatically clears after 20 messages, which creates an edge case where repeats could happen but it should be exceedingly rare.