### PR TITLE
Updating class category system

### DIFF
--- a/bot-lib/src/commands/class_roles.rs
+++ b/bot-lib/src/commands/class_roles.rs
@@ -1,0 +1,99 @@
+use crate::data::PoiseContext;
+use color_eyre::eyre::{OptionExt, Result, WrapErr};
+
+#[poise::command(slash_command, prefix_command, rename = "join_class")]
+pub async fn add_class_role(
+    ctx: PoiseContext<'_>,
+    #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
+) -> Result<()> {
+    let author = ctx.author();
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let roles = guild.roles(ctx).await?;
+
+    let role_name = format!("CS {}", number);
+    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
+        ctx.say("Couldn't find the class!").await?;
+        return Ok(());
+    };
+
+    guild
+        .member(ctx, author.id)
+        .await
+        .wrap_err("Couldn't get member")?
+        .add_role(ctx, role_id)
+        .await
+        .wrap_err("Couldn't add role")?;
+    {
+        let members = &mut ctx
+            .framework()
+            .user_data
+            .config
+            .write()
+            .await
+            .bot_react_role_members;
+
+        let author_id = author.id.into();
+
+        members.retain(
+            |member| matches!(member, crate::config::ReactRole { user_id, .. } if user_id != &author_id),
+        );
+
+        members.push(crate::config::ReactRole {
+            user_id: author_id,
+            react: true,
+        });
+    }
+
+    ctx.say("Joined class!").await?;
+
+    Ok(())
+}
+
+#[poise::command(slash_command, prefix_command, rename = "leave_class")]
+pub async fn remove_class_role(
+    ctx: PoiseContext<'_>,
+    #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
+) -> Result<()> {
+    let author = ctx.author();
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let roles = guild.roles(ctx).await?;
+
+    let role_name = format!("CS {}", number);
+    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
+        ctx.say("Couldn't find the class!").await?;
+        return Ok(());
+    };
+
+    guild
+        .member(ctx, author.id)
+        .await
+        .wrap_err("Couldn't get member")?
+        .remove_role(ctx, role_id)
+        .await
+        .wrap_err("Couldn't remove role")?;
+
+    {
+        let members = &mut ctx
+            .framework()
+            .user_data
+            .config
+            .write()
+            .await
+            .bot_react_role_members;
+
+        let author_id = author.id.into();
+
+        members.retain(
+            |member| matches!(member, crate::config::ReactRole { user_id, .. } if user_id != &author_id),
+        );
+
+        members.push(crate::config::ReactRole {
+            user_id: author_id,
+            react: false,
+        });
+    }
+
+    ctx.say("Left class!").await?;
+
+    Ok(())
+}

--- a/bot-lib/src/commands/class_roles.rs
+++ b/bot-lib/src/commands/class_roles.rs
@@ -13,9 +13,9 @@ pub async fn add_class_role(
     author
         .add_role(ctx, role_id)
         .await
-        .wrap_err("Couldn't remove role")?;
+        .wrap_err("Couldn't add role")?;
 
-    ctx.say("Left class!").await?;
+    ctx.say("Joined class!").await?;
 
     Ok(())
 }

--- a/bot-lib/src/commands/class_roles.rs
+++ b/bot-lib/src/commands/class_roles.rs
@@ -23,26 +23,6 @@ pub async fn add_class_role(
         .add_role(ctx, role_id)
         .await
         .wrap_err("Couldn't add role")?;
-    {
-        let members = &mut ctx
-            .framework()
-            .user_data
-            .config
-            .write()
-            .await
-            .bot_react_role_members;
-
-        let author_id = author.id.into();
-
-        members.retain(
-            |member| matches!(member, crate::config::ReactRole { user_id, .. } if user_id != &author_id),
-        );
-
-        members.push(crate::config::ReactRole {
-            user_id: author_id,
-            react: true,
-        });
-    }
 
     ctx.say("Joined class!").await?;
 
@@ -71,27 +51,6 @@ pub async fn remove_class_role(
         .remove_role(ctx, role_id)
         .await
         .wrap_err("Couldn't remove role")?;
-
-    {
-        let members = &mut ctx
-            .framework()
-            .user_data
-            .config
-            .write()
-            .await
-            .bot_react_role_members;
-
-        let author_id = author.id.into();
-
-        members.retain(
-            |member| matches!(member, crate::config::ReactRole { user_id, .. } if user_id != &author_id),
-        );
-
-        members.push(crate::config::ReactRole {
-            user_id: author_id,
-            react: false,
-        });
-    }
 
     ctx.say("Left class!").await?;
 

--- a/bot-lib/src/commands/class_roles.rs
+++ b/bot-lib/src/commands/class_roles.rs
@@ -1,53 +1,39 @@
+use crate::commands::{get_author, get_role};
 use crate::data::PoiseContext;
-use color_eyre::eyre::{OptionExt, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr};
 
 #[poise::command(slash_command, prefix_command, rename = "join_class", ephemeral = true)]
 pub async fn add_class_role(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
 ) -> Result<()> {
-    let author = ctx.author();
-    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
-    let roles = guild.roles(ctx).await?;
+    let author = get_author(ctx).await?;
+    let role_id = get_role(ctx, number).await?;
 
-    let role_name = format!("CS {}", number);
-    let Some((role_id, _)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
-        ctx.say("Couldn't find the class!").await?;
-        return Ok(());
-    };
-
-    guild
-        .member(ctx, author.id)
-        .await
-        .wrap_err("Couldn't get member")?
+    author
         .add_role(ctx, role_id)
         .await
-        .wrap_err("Couldn't add role")?;
+        .wrap_err("Couldn't remove role")?;
 
-    ctx.say("Joined class!").await?;
+    ctx.say("Left class!").await?;
 
     Ok(())
 }
 
-#[poise::command(slash_command, prefix_command, rename = "leave_class", ephemeral = true)]
+#[poise::command(
+    slash_command,
+    prefix_command,
+    rename = "leave_class",
+    ephemeral = true
+)]
 pub async fn remove_class_role(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
 ) -> Result<()> {
-    let author = ctx.author();
-    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
-    let roles = guild.roles(ctx).await?;
+    let author = get_author(ctx).await?;
+    let role_id = get_role(ctx, number).await?;
 
-    let role_name = format!("CS {}", number);
-    let Some((role_id, _)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
-        ctx.say("Couldn't find the class!").await?;
-        return Ok(());
-    };
-
-    guild
-        .member(ctx, author.id)
-        .await
-        .wrap_err("Couldn't get member")?
+    author
         .remove_role(ctx, role_id)
         .await
         .wrap_err("Couldn't remove role")?;

--- a/bot-lib/src/commands/class_roles.rs
+++ b/bot-lib/src/commands/class_roles.rs
@@ -1,7 +1,7 @@
 use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result, WrapErr};
 
-#[poise::command(slash_command, prefix_command, rename = "join_class")]
+#[poise::command(slash_command, prefix_command, rename = "join_class", ephemeral = true)]
 pub async fn add_class_role(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
@@ -11,7 +11,7 @@ pub async fn add_class_role(
     let roles = guild.roles(ctx).await?;
 
     let role_name = format!("CS {}", number);
-    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
+    let Some((role_id, _)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
         ctx.say("Couldn't find the class!").await?;
         return Ok(());
     };
@@ -29,7 +29,7 @@ pub async fn add_class_role(
     Ok(())
 }
 
-#[poise::command(slash_command, prefix_command, rename = "leave_class")]
+#[poise::command(slash_command, prefix_command, rename = "leave_class", ephemeral = true)]
 pub async fn remove_class_role(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
@@ -39,7 +39,7 @@ pub async fn remove_class_role(
     let roles = guild.roles(ctx).await?;
 
     let role_name = format!("CS {}", number);
-    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
+    let Some((role_id, _)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
         ctx.say("Couldn't find the class!").await?;
         return Ok(());
     };

--- a/bot-lib/src/commands/create_class_category.rs
+++ b/bot-lib/src/commands/create_class_category.rs
@@ -8,6 +8,7 @@ const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
 #[poise::command(
     slash_command,
     required_permissions = "MANAGE_CHANNELS",
+    description_localized("en-US", "Creates a class category")
 )]
 pub async fn create_class_category(
     ctx: PoiseContext<'_>,

--- a/bot-lib/src/commands/create_class_category.rs
+++ b/bot-lib/src/commands/create_class_category.rs
@@ -5,7 +5,10 @@ use serenity::{ChannelType, PermissionOverwrite, PermissionOverwriteType, Permis
 
 const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
 
-#[poise::command(slash_command, required_permissions = "MANAGE_CHANNELS")]
+#[poise::command(
+    slash_command,
+    required_permissions = "MANAGE_CHANNELS",
+)]
 pub async fn create_class_category(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -1,0 +1,48 @@
+use crate::data::PoiseContext;
+use color_eyre::eyre::{OptionExt, Result};
+
+#[poise::command(
+    slash_command,
+    required_permissions = "MANAGE_CHANNELS",
+    description_localized("en-US", "Deletes a class category")
+)]
+pub async fn delete_class_category(
+    ctx: PoiseContext<'_>,
+    #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
+) -> Result<()> {
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let channels = guild.channels(ctx).await?;
+    let roles = guild.roles(ctx).await?;
+    let number_string = number.to_string();
+
+    let category_and_role_name = format!("CS {}", &number_string);
+    let Some((category_channel_id, category_channel)) = channels
+        .iter()
+        .find(|x| x.1.name.contains(&category_and_role_name))
+        else {
+            ctx.say("Couldn't find the category!").await?;
+            return Ok(());
+        };
+
+    let children_channels = channels.iter().filter(|x| {
+        return match x.1.parent_id {
+            Some(parent) => parent.eq(category_channel_id),
+            None => false,
+        }
+    });
+
+    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&category_and_role_name)) else {
+        ctx.say("Couldn't find the role!").await?;
+        return Ok(());
+    };
+
+    category_channel.delete(ctx).await?;
+    for channel in children_channels {
+        channel.1.delete(ctx).await?;
+    }
+    guild.delete_role(ctx, role_id).await?;
+
+
+    ctx.say("Success!").await?;
+    Ok(())
+}

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -31,7 +31,7 @@ pub async fn delete_class_category(
         }
     });
 
-    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&category_and_role_name)) else {
+    let Some((role_id, _)) = roles.iter().find(|x| x.1.name.contains(&category_and_role_name)) else {
         ctx.say("Couldn't find the role!").await?;
         return Ok(());
     };

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -15,18 +15,15 @@ pub async fn delete_class_category(
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let channels = guild.channels(ctx).await?;
 
-    let category_and_role_name = format!("CS {}", number);
-    let category_channel = &get_channels(
-        ctx,
-        guild,
-        Regex::new(&format!("^{}$", category_and_role_name))?,
-    )
-    .await?[0];
+    let category_regex = format!("^CS {}$", number);
+    let gotten_channels = &get_channels(ctx, guild, Regex::new(&category_regex)?).await?;
+    let category_channel = gotten_channels
+        .first()
+        .ok_or_eyre("Could not find category channel!")?;
 
-    let children_channels = channels.iter().filter(|x| match x.1.parent_id {
-        Some(parent) => parent.eq(&category_channel.id),
-        None => false,
-    });
+    let children_channels = channels
+        .iter()
+        .filter(|x| matches!(x.1.parent_id, Some(parent) if parent.eq(&category_channel.id)));
 
     let role_id = get_role(ctx, number).await?;
 

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -1,4 +1,4 @@
-use crate::commands::find_channels;
+use crate::commands::{get_channels, get_role};
 use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result};
 use regex::Regex;
@@ -14,11 +14,10 @@ pub async fn delete_class_category(
 ) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let channels = guild.channels(ctx).await?;
-    let roles = guild.roles(ctx).await?;
     let number_string = number.to_string();
 
     let category_and_role_name = format!("CS {}", &number_string);
-    let category_channel = &find_channels(
+    let category_channel = &get_channels(
         ctx,
         guild,
         Regex::new(&format!("^{}$", category_and_role_name))?,
@@ -30,13 +29,7 @@ pub async fn delete_class_category(
         None => false,
     });
 
-    let Some((role_id, _)) = roles
-        .iter()
-        .find(|x| x.1.name.contains(&category_and_role_name))
-    else {
-        ctx.say("Couldn't find the role!").await?;
-        return Ok(());
-    };
+    let role_id = get_role(ctx, number).await?;
 
     category_channel.delete(ctx).await?;
     for channel in children_channels {

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -14,9 +14,8 @@ pub async fn delete_class_category(
 ) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let channels = guild.channels(ctx).await?;
-    let number_string = number.to_string();
 
-    let category_and_role_name = format!("CS {}", &number_string);
+    let category_and_role_name = format!("CS {}", number);
     let category_channel = &get_channels(
         ctx,
         guild,

--- a/bot-lib/src/commands/delete_class_category.rs
+++ b/bot-lib/src/commands/delete_class_category.rs
@@ -25,7 +25,7 @@ pub async fn delete_class_category(
         };
 
     let children_channels = channels.iter().filter(|x| {
-        return match x.1.parent_id {
+        match x.1.parent_id {
             Some(parent) => parent.eq(category_channel_id),
             None => false,
         }

--- a/bot-lib/src/commands/mod.rs
+++ b/bot-lib/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod register;
 pub mod remove_bot_role;
 pub mod timeout;
 pub mod reset_class_categories;
+pub mod delete_class_category;

--- a/bot-lib/src/commands/mod.rs
+++ b/bot-lib/src/commands/mod.rs
@@ -9,3 +9,21 @@ pub mod timeout;
 pub mod reset_class_categories;
 pub mod delete_class_category;
 pub mod class_roles;
+
+use color_eyre::eyre::Result;
+use poise::serenity_prelude::{GuildChannel, GuildId};
+use regex::Regex;
+use crate::data::PoiseContext;
+
+/// Finds all channels in the given guild, where the name matches the given regex
+pub async fn find_channels(ctx: PoiseContext<'_>, guild: GuildId, pattern: Regex) -> Result<Vec<GuildChannel>>{
+    let channels = guild.channels(ctx).await?;
+
+    let filtered_channels = channels
+        .iter()
+        .filter(|channel| pattern.is_match(&channel.1.name))
+        .map(|x| x.1.to_owned())
+        .collect::<Vec<GuildChannel>>();
+
+    Ok(filtered_channels)
+}

--- a/bot-lib/src/commands/mod.rs
+++ b/bot-lib/src/commands/mod.rs
@@ -1,29 +1,57 @@
 pub mod add_bot_role;
+pub mod class_roles;
 pub mod course_catalog;
 pub mod create_class_category;
+pub mod delete_class_category;
 pub mod help;
 pub mod lynch;
 pub mod register;
 pub mod remove_bot_role;
-pub mod timeout;
 pub mod reset_class_categories;
-pub mod delete_class_category;
-pub mod class_roles;
+pub mod timeout;
 
-use color_eyre::eyre::Result;
-use poise::serenity_prelude::{GuildChannel, GuildId};
-use regex::Regex;
 use crate::data::PoiseContext;
+use color_eyre::eyre::{OptionExt, Result};
+use color_eyre::Report;
+use poise::serenity_prelude::{GuildChannel, GuildId, Member, RoleId};
+use regex::Regex;
 
 /// Finds all channels in the given guild, where the name matches the given regex
-pub async fn find_channels(ctx: PoiseContext<'_>, guild: GuildId, pattern: Regex) -> Result<Vec<GuildChannel>>{
+pub async fn get_channels(
+    ctx: PoiseContext<'_>,
+    guild: GuildId,
+    pattern: Regex,
+) -> Result<Vec<GuildChannel>> {
     let channels = guild.channels(ctx).await?;
 
     let filtered_channels = channels
-        .iter()
-        .filter(|channel| pattern.is_match(&channel.1.name))
-        .map(|x| x.1.to_owned())
-        .collect::<Vec<GuildChannel>>();
+        .values()
+        .filter(|channel| pattern.is_match(&channel.name))
+        .map(|x| x.to_owned())
+        .collect();
 
     Ok(filtered_channels)
+}
+
+pub async fn get_role(ctx: PoiseContext<'_>, number: u32) -> Result<RoleId> {
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let roles = guild.roles(ctx).await?;
+
+    let role_name = format!("CS {}", number);
+    let Some(role_id) = roles
+        .iter()
+        .find_map(|(role_id, role)| role.name.contains(&role_name).then_some(*role_id))
+    else {
+        ctx.say("Couldn't find the class!").await?;
+        return Err(Report::msg("Class role not found"));
+    };
+
+    Ok(role_id)
+}
+
+pub async fn get_author(ctx: PoiseContext<'_>) -> Result<Member> {
+    let author = ctx.author();
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+
+    Ok(guild.member(ctx, author.id).await?)
 }

--- a/bot-lib/src/commands/mod.rs
+++ b/bot-lib/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod remove_bot_role;
 pub mod timeout;
 pub mod reset_class_categories;
 pub mod delete_class_category;
+pub mod class_roles;

--- a/bot-lib/src/commands/mod.rs
+++ b/bot-lib/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod lynch;
 pub mod register;
 pub mod remove_bot_role;
 pub mod timeout;
+pub mod reset_class_categories;

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -2,9 +2,7 @@ use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result, WrapErr};
 use poise::serenity_prelude::{self as serenity};
 use regex::Regex;
-use serenity::{ChannelType, RoleId};
-
-const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
+use serenity::{ChannelType};
 
 pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -83,7 +83,7 @@ pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
 
     let removed_categories = channels
         .iter()
-        .map(|channel| (&channel.1.name).to_string())
+        .map(|channel| channel.1.name.to_string())
         .filter(|name| general_channel_pattern.is_match(name))
         .map(|name| {
             name[0..4]

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -1,0 +1,71 @@
+use crate::data::PoiseContext;
+use color_eyre::eyre::{OptionExt, Result, WrapErr};
+use poise::serenity_prelude::{self as serenity, ChannelId, GuildChannel};
+use serenity::{ChannelType, PermissionOverwrite, PermissionOverwriteType, Permissions, RoleId};
+use regex::Regex;
+
+const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
+
+pub async fn reset_class_category_backend(
+    ctx: PoiseContext<'_>,
+    number: u32,
+) -> Result<()> {
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let channels = guild.channels(ctx).await?;
+
+    let number_string = number.to_string();
+    let general_channel_name = number_string + "-general";
+    let Some ((general_channel_id, general_channel)) = channels.iter().find(|x| {
+        x.1.name.contains(&general_channel_name)
+    }) else {ctx.say("Couldn't find the general channel!").await?; return Ok(());};
+
+    let category_id = general_channel.parent_id.expect("Couldn't get category ID!");
+
+    general_channel.delete(ctx).await?;
+
+    guild
+        .create_channel(
+            ctx,
+            serenity::CreateChannel::new(general_channel_name)
+                .kind(ChannelType::Text)
+                .category(category_id),
+        )
+        .await
+        .wrap_err("Couldn't create general channel")?;
+
+    Ok(())
+}
+
+#[poise::command(slash_command, required_permissions = "MANAGE_CHANNELS")]
+pub async fn reset_class_category(
+    ctx: PoiseContext<'_>,
+    #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
+) -> Result<()> {
+    reset_class_category_backend(ctx, number).await?;
+    ctx.say("Success!").await?;
+    Ok(())
+}
+
+#[poise::command(slash_command, required_permissions = "MANAGE_CHANNELS")]
+pub async fn reset_class_categories(
+    ctx: PoiseContext<'_>,
+) -> Result<()> {
+    let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
+    let channels = guild.channels(ctx).await?;
+
+    let general_channel_pattern = Regex::new(r"\d{4}-general").unwrap();
+
+    let removed_categories = channels.iter().map(|channel| {
+        (&channel.1.name).to_string()
+    }).collect::<Vec<String>>().into_iter().filter(|name| {
+         general_channel_pattern.is_match(name)
+    }).collect::<Vec<String>>().into_iter().map(|name| {
+        name[0..4].parse::<u32>().expect("Parse error on class category name")
+    }).collect::<Vec<u32>>();
+
+    for category in removed_categories {
+        reset_class_category_backend(ctx, category).await?;
+    }
+
+    Ok(())
+}

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -1,32 +1,36 @@
 use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result, WrapErr};
 use poise::serenity_prelude::{self as serenity};
-use serenity::{ChannelType, RoleId};
 use regex::Regex;
+use serenity::{ChannelType, RoleId};
 
 const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
 
-pub async fn reset_class_category_backend(
-    ctx: PoiseContext<'_>,
-    number: u32,
-) -> Result<()> {
+pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let channels = guild.channels(ctx).await?;
     let roles = guild.roles(ctx).await?;
-    let members  = guild.members(ctx, None, None).await?;
+    let members = guild.members(ctx, None, None).await?;
     let number_string = number.to_string();
 
     let general_channel_name = format!("{}-general", &number_string);
-    let Some ((_general_channel_id, general_channel)) = channels.iter().find(|x| {
-        x.1.name.contains(&general_channel_name)
-    }) else {ctx.say("Couldn't find the general channel!").await?; return Ok(());};
+    let Some((_general_channel_id, general_channel)) = channels
+        .iter()
+        .find(|x| x.1.name.contains(&general_channel_name))
+    else {
+        ctx.say("Couldn't find the general channel!").await?;
+        return Ok(());
+    };
 
     let role_name = format!("CS {}", number_string);
-    let Some((role_id, _role)) = roles.iter().find(|x| {
-        x.1.name.contains(&role_name)
-    }) else {ctx.say("Couldn't find the role!").await?; return Ok(());};
+    let Some((role_id, _role)) = roles.iter().find(|x| x.1.name.contains(&role_name)) else {
+        ctx.say("Couldn't find the role!").await?;
+        return Ok(());
+    };
 
-    let category_id = general_channel.parent_id.expect("Couldn't get category ID!");
+    let category_id = general_channel
+        .parent_id
+        .expect("Couldn't get category ID!");
 
     general_channel.delete(ctx).await?;
 
@@ -40,10 +44,9 @@ pub async fn reset_class_category_backend(
         .await
         .wrap_err("Couldn't create general channel")?;
 
-
-    let memebrs_with_role = members.iter().filter(|member| {
-        member.roles.contains(role_id)
-    });
+    let memebrs_with_role = members
+        .iter()
+        .filter(|member| member.roles.contains(role_id));
 
     for member in memebrs_with_role {
         member.remove_role(ctx, role_id).await?;
@@ -52,7 +55,10 @@ pub async fn reset_class_category_backend(
     Ok(())
 }
 
-#[poise::command(slash_command, required_permissions = "MANAGE_CHANNELS")]
+#[poise::command(
+    slash_command,
+    required_permissions = "MANAGE_CHANNELS",
+)]
 pub async fn reset_class_category(
     ctx: PoiseContext<'_>,
     #[description = "The class number, eg. for CS2420 put in \"2420\""] number: u32,
@@ -62,26 +68,32 @@ pub async fn reset_class_category(
     Ok(())
 }
 
-#[poise::command(slash_command, required_permissions = "MANAGE_CHANNELS")]
-pub async fn reset_class_categories(
-    ctx: PoiseContext<'_>,
-) -> Result<()> {
+#[poise::command(
+    slash_command,
+    required_permissions = "MANAGE_CHANNELS",
+)]
+pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let channels = guild.channels(ctx).await?;
 
     let general_channel_pattern = Regex::new(r"\d{4}-general").unwrap();
 
-    let removed_categories = channels.iter().map(|channel| {
-        (&channel.1.name).to_string()
-    }).collect::<Vec<String>>().into_iter().filter(|name| {
-         general_channel_pattern.is_match(name)
-    }).collect::<Vec<String>>().into_iter().map(|name| {
-        name[0..4].parse::<u32>().expect("Parse error on class category name")
-    }).collect::<Vec<u32>>();
+    let removed_categories = channels
+        .iter()
+        .map(|channel| (&channel.1.name).to_string())
+        .filter(|name| general_channel_pattern.is_match(name))
+        .map(|name| {
+            name[0..4]
+                .parse::<u32>()
+                .expect("Parse error on class category name")
+        })
+        .collect::<Vec<u32>>();
 
     for category in removed_categories {
         reset_class_category_backend(ctx, category).await?;
     }
+
+    ctx.say("Success!").await?;
 
     Ok(())
 }

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -58,6 +58,10 @@ pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) ->
 #[poise::command(
     slash_command,
     required_permissions = "MANAGE_CHANNELS",
+    description_localized(
+        "en-US",
+        "Resets a class category (clears the general channel, removes the role from everyone)"
+    )
 )]
 pub async fn reset_class_category(
     ctx: PoiseContext<'_>,
@@ -71,6 +75,7 @@ pub async fn reset_class_category(
 #[poise::command(
     slash_command,
     required_permissions = "MANAGE_CHANNELS",
+    description_localized("en-US", "Resets all class categories")
 )]
 pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -10,7 +10,10 @@ pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) ->
     let members = guild.members(ctx, None, None).await?;
 
     let general_channel_name = format!("{}-general", number);
-    let general_channel = &get_channels(ctx, guild, Regex::new(&general_channel_name)?).await?[0];
+    let gotten_channels = get_channels(ctx, guild, Regex::new(&general_channel_name)?).await?;
+    let general_channel = gotten_channels
+        .first()
+        .ok_or_eyre("Could not find general channel!")?;
 
     let role_id = get_role(ctx, number).await?;
 
@@ -69,7 +72,10 @@ pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
         .await?
         .into_iter()
         .map(|channel| {
-            channel.name[0..4]
+            channel
+                .name
+                .get(0..4)
+                .unwrap_or("Intentional parse error")
                 .parse::<u32>()
                 .context("Parse error")
         });

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -42,11 +42,11 @@ pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) ->
         .await
         .wrap_err("Couldn't create general channel")?;
 
-    let memebrs_with_role = members
+    let members_with_role = members
         .iter()
         .filter(|member| member.roles.contains(role_id));
 
-    for member in memebrs_with_role {
+    for member in members_with_role {
         member.remove_role(ctx, role_id).await?;
     }
 

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -2,7 +2,7 @@ use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result, WrapErr};
 use poise::serenity_prelude::{self as serenity};
 use regex::Regex;
-use serenity::{ChannelType};
+use serenity::ChannelType;
 
 pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) -> Result<()> {
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -9,14 +9,14 @@ pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) ->
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let members = guild.members(ctx, None, None).await?;
 
-    let general_channel_name = format!("{}-general", number);
+    let general_channel_name = format!("^{}-general$", number);
     let general_channel = &get_channels(ctx, guild, Regex::new(&general_channel_name)?).await?[0];
 
     let role_id = get_role(ctx, number).await?;
 
     let category_id = general_channel
         .parent_id
-        .expect("Couldn't get category ID!");
+        .ok_or_eyre("Couldn't get category ID!")?;
 
     general_channel.delete(ctx).await?;
 
@@ -71,7 +71,7 @@ pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
         .map(|channel| {
             channel.name[0..4]
                 .parse::<u32>()
-                .expect("Parse error on class category name")
+                .unwrap_or(0)
         });
 
     for category in removed_categories {

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -1,7 +1,7 @@
 use crate::data::PoiseContext;
 use color_eyre::eyre::{OptionExt, Result, WrapErr};
-use poise::serenity_prelude::{self as serenity, ChannelId, GuildChannel};
-use serenity::{ChannelType, PermissionOverwrite, PermissionOverwriteType, Permissions, RoleId};
+use poise::serenity_prelude::{self as serenity};
+use serenity::{ChannelType, RoleId};
 use regex::Regex;
 
 const MOD_ROLE_ID: RoleId = RoleId::new(1192863993883279532);
@@ -15,7 +15,7 @@ pub async fn reset_class_category_backend(
 
     let number_string = number.to_string();
     let general_channel_name = number_string + "-general";
-    let Some ((general_channel_id, general_channel)) = channels.iter().find(|x| {
+    let Some ((_general_channel_id, general_channel)) = channels.iter().find(|x| {
         x.1.name.contains(&general_channel_name)
     }) else {ctx.say("Couldn't find the general channel!").await?; return Ok(());};
 

--- a/bot-lib/src/commands/reset_class_categories.rs
+++ b/bot-lib/src/commands/reset_class_categories.rs
@@ -9,7 +9,7 @@ pub async fn reset_class_category_backend(ctx: PoiseContext<'_>, number: u32) ->
     let guild = ctx.guild().ok_or_eyre("Couldn't get guild")?.id;
     let members = guild.members(ctx, None, None).await?;
 
-    let general_channel_name = format!("^{}-general$", number);
+    let general_channel_name = format!("{}-general", number);
     let general_channel = &get_channels(ctx, guild, Regex::new(&general_channel_name)?).await?[0];
 
     let role_id = get_role(ctx, number).await?;
@@ -71,11 +71,11 @@ pub async fn reset_class_categories(ctx: PoiseContext<'_>) -> Result<()> {
         .map(|channel| {
             channel.name[0..4]
                 .parse::<u32>()
-                .unwrap_or(0)
+                .context("Parse error")
         });
 
     for category in removed_categories {
-        reset_class_category_backend(ctx, category).await?;
+        reset_class_category_backend(ctx, category?).await?;
     }
 
     ctx.say("Success!").await?;

--- a/bot-lib/src/config.rs
+++ b/bot-lib/src/config.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use std::sync::Arc;
+use poise::serenity_prelude::ChannelId;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct ReactRole {
@@ -49,6 +50,8 @@ pub struct Config {
     /// This may be rate limiting us, so we cache it.
     #[serde(skip)]
     pub bot_react_role_members: Vec<ReactRole>,
+    /// The list of class categories we currently support
+    pub class_categories: Vec<ChannelId>,
 }
 
 impl PartialEq for Config {
@@ -78,6 +81,7 @@ impl Default for Config {
             skip_hit_rate_text: "".to_owned(),
             config_path: "".to_owned(),
             bot_react_role_members: vec![],
+            class_categories: vec![],
         }
     }
 }

--- a/bot-lib/src/config.rs
+++ b/bot-lib/src/config.rs
@@ -64,6 +64,7 @@ impl PartialEq for Config {
             && self.default_hit_rate == other.default_hit_rate
             && self.skip_hit_rate_text == other.skip_hit_rate_text
             && self.config_path == other.config_path
+            && self.class_categories == other.class_categories
     }
 }
 

--- a/bot-lib/src/config.rs
+++ b/bot-lib/src/config.rs
@@ -4,10 +4,10 @@ use chrono::{DateTime, Utc};
 use chrono::{Duration, Local};
 use color_eyre::eyre::{Result, WrapErr};
 use parking_lot::Mutex;
+use poise::serenity_prelude::ChannelId;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use std::sync::Arc;
-use poise::serenity_prelude::ChannelId;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct ReactRole {

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -3,6 +3,7 @@ use bot_lib::{
         add_bot_role::add_bot_role,
         course_catalog::course_catalog,
         create_class_category::create_class_category,
+        reset_class_categories::{reset_class_category, reset_class_categories},
         help::help,
         lynch::{lynch, update_interval},
         register::register,
@@ -63,6 +64,8 @@ async fn main() -> Result<()> {
                 remove_bot_role(),
                 timeout(),
                 lynch(),
+                reset_class_category(),
+                reset_class_categories(),
             ],
             event_handler: |ctx, event, framework, data| {
                 Box::pin(event_handler(ctx, event, framework, data))

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -10,6 +10,7 @@ use bot_lib::{
         register::register,
         remove_bot_role::remove_bot_role,
         timeout::timeout,
+        class_roles::{add_class_role, remove_class_role},
     },
     config,
     data::AppState,
@@ -68,6 +69,8 @@ async fn main() -> Result<()> {
                 reset_class_category(),
                 reset_class_categories(),
                 delete_class_category(),
+                add_class_role(),
+                remove_class_role()
             ],
             event_handler: |ctx, event, framework, data| {
                 Box::pin(event_handler(ctx, event, framework, data))

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -3,6 +3,7 @@ use bot_lib::{
         add_bot_role::add_bot_role,
         course_catalog::course_catalog,
         create_class_category::create_class_category,
+        delete_class_category::delete_class_category,
         reset_class_categories::{reset_class_category, reset_class_categories},
         help::help,
         lynch::{lynch, update_interval},
@@ -66,6 +67,7 @@ async fn main() -> Result<()> {
                 lynch(),
                 reset_class_category(),
                 reset_class_categories(),
+                delete_class_category(),
             ],
             event_handler: |ctx, event, framework, data| {
                 Box::pin(event_handler(ctx, event, framework, data))

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1,16 +1,16 @@
 use bot_lib::{
     commands::{
         add_bot_role::add_bot_role,
+        class_roles::{add_class_role, remove_class_role},
         course_catalog::course_catalog,
         create_class_category::create_class_category,
         delete_class_category::delete_class_category,
-        reset_class_categories::{reset_class_category, reset_class_categories},
         help::help,
         lynch::{lynch, update_interval},
         register::register,
         remove_bot_role::remove_bot_role,
+        reset_class_categories::{reset_class_categories, reset_class_category},
         timeout::timeout,
-        class_roles::{add_class_role, remove_class_role},
     },
     config,
     data::AppState,
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
                 reset_class_categories(),
                 delete_class_category(),
                 add_class_role(),
-                remove_class_role()
+                remove_class_role(),
             ],
             event_handler: |ctx, event, framework, data| {
                 Box::pin(event_handler(ctx, event, framework, data))

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 default_text_detect_cooldown = 45
 bot_react_role_id = 1173465249823850496
 default_hit_rate = 0.21
-guild_id = 1239667754483580999
+guild_id = 1065373537591894086
 skip_hit_rate_text = "KINGFISHER PLEASE"
 skip_duration_text = "HIT ME BABY ONE MORE TIME"
 

--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,11 @@
 default_text_detect_cooldown = 45
 bot_react_role_id = 1173465249823850496
 default_hit_rate = 0.21
-guild_id = 1065373537591894086
+guild_id = 1239667754483580999
 skip_hit_rate_text = "KINGFISHER PLEASE"
 skip_duration_text = "HIT ME BABY ONE MORE TIME"
+
+class_categories = []
 
 help_text = """
 [KingFisher](<https://github.com/coravacav/uofu-cs-discord-bot>) is an opportunistic comedian (RNG) that was written in [Rust](<https://doc.rust-lang.org/book/>) (the greatest language) for this server (of nerds).


### PR DESCRIPTION
This makes a bunch of changes to the class category systems, such as allowing channel resets, class joins/leaves, and category deletions from the command interface. The current version all works based on autofinding, although I did add a config entry so we could store channel IDs/names in config.toml (although the autofinding works fine, and I think we might want to wait on the database to do it without autofinding). 