### PR TITLE
Remove update class category command

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -67,7 +67,6 @@ async fn main() -> Result<()> {
                 db_admin(),
                 parry(),
                 remove_dog_role(),
-                update_class_category(),
                 add_class_role(),
                 sathya(),
                 llm_prompt(),


### PR DESCRIPTION
The update class category command is kinda redundant. We can just set class names/descriptions in the create class category command.